### PR TITLE
Adicionado validação para as rota dos professores

### DIFF
--- a/app/Controllers/Http/TeachersController.ts
+++ b/app/Controllers/Http/TeachersController.ts
@@ -1,6 +1,6 @@
 import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 import Teacher from 'App/Models/Teacher'
-import { DateTime } from 'luxon'
+import personSchema from 'App/Schemas/personSchema'
 
 export default class TeachersController {
   public async show({ request, response }: HttpContextContract) {
@@ -22,19 +22,19 @@ export default class TeachersController {
     }
   }
   public async store({ request, response }: HttpContextContract) {
-    const body: Record<string, any> = request.body()
+    const payload = await request.validate({ schema: personSchema })
     try {
-      let teacher: Teacher | null = await Teacher.findBy('matricula', body.matricula)
+      let teacher: Teacher | null = await Teacher.findBy('matricula', payload.matricula)
       if (teacher) {
         response.status(409)
         return { message: 'Professor já se encontra cadastrado!' }
       }
-      let dataParsed: DateTime = DateTime.fromFormat(body.nascimento, 'yyyy-LL-dd')
+      // let dataParsed: DateTime = DateTime.fromFormat(body.nascimento, 'yyyy-LL-dd')
       teacher = await Teacher.create({
-        nome: body.nome,
-        email: body.email,
-        matricula: body.matricula,
-        nascimento: dataParsed,
+        nome: payload.nome,
+        email: payload.email,
+        matricula: payload.matricula,
+        nascimento: payload.nascimento,
       })
       response.status(201)
       return teacher
@@ -46,21 +46,21 @@ export default class TeachersController {
     }
   }
   public async update({ request, response }: HttpContextContract) {
-    const body: Record<string, any> = request.body()
+    const payload = await request.validate({ schema: personSchema })
 
     try {
-      const teacher: Teacher | null = await Teacher.findBy('matricula', body.matricula)
+      const teacher: Teacher | null = await Teacher.findBy('matricula', payload.matricula)
       if (!teacher) {
         response.status(404)
         return { message: 'Professor não encontrado!' }
       }
-      let dataParsed: DateTime = DateTime.fromFormat(body.nascimento, 'yyyy-LL-dd')
+
       let dataUpdate: Teacher = await teacher
         .merge({
-          nome: body.nome,
-          email: body.email,
-          matricula: body.matricula,
-          nascimento: dataParsed,
+          nome: payload.nome,
+          email: payload.email,
+          matricula: payload.matricula,
+          nascimento: payload.nascimento,
         })
         .save()
       response.status(200)

--- a/app/Schemas/personSchema.ts
+++ b/app/Schemas/personSchema.ts
@@ -1,0 +1,8 @@
+import { schema, rules } from '@ioc:Adonis/Core/Validator'
+const personSchema = schema.create({
+  nome: schema.string([rules.alpha({ allow: ['space'] })]),
+  email: schema.string([rules.email({ ignoreMaxLength: true })]),
+  matricula: schema.string({ trim: true }),
+  nascimento: schema.date({ format: 'yyyy-MM-dd' }),
+})
+export default personSchema

--- a/tests/functional/teacher.spec.ts
+++ b/tests/functional/teacher.spec.ts
@@ -3,7 +3,7 @@ import { test } from '@japa/runner'
 test.group('Teacher', () => {
   test('Cadastrar dados do Professor', async ({ client }) => {
     const response = await client.post('/api/teacher/create').form({
-      nome: 'Professor 1',
+      nome: 'Professor name',
       email: 'professor_1@gmail.com',
       nascimento: '2000-03-17',
       matricula: 'P7342',
@@ -11,7 +11,7 @@ test.group('Teacher', () => {
 
     response.assertStatus(201)
     response.assertBodyContains({
-      nome: 'Professor 1',
+      nome: 'Professor name',
       email: 'professor_1@gmail.com',
       nascimento: '2000-03-17',
       matricula: 'P7342',
@@ -22,7 +22,7 @@ test.group('Teacher', () => {
 
     response.assertStatus(200)
     response.assertBodyContains({
-      nome: 'Professor 1',
+      nome: 'Professor name',
       email: 'professor_1@gmail.com',
       nascimento: '2000-03-17',
       matricula: 'P7342',


### PR DESCRIPTION
###### :sparkles: Foi adicionado pasta para Schemas:
A pasta está no caminho relativo './app/Schemas'.
O padrão usado para novos Schemas é camelcase.

###### :sparkles: Foi adicionado um Schema para o model Person
O Schema possui o seguinte código:
```
{
  nome: schema.string([rules.alpha({ allow: ['space'] })]),
  email: schema.string([rules.email({ ignoreMaxLength: true })]),
  matricula: schema.string({ trim: true }),
  nascimento: schema.date({ format: 'yyyy-MM-dd' }),
}
```
As validações feitas foram:

- Em nome, a condição verificada é a presença de números, sinais e caracteres especiais. Espaços são permitidos;
- Em email, foi verificada se a estrutura de email está presente. Um tamanho máximo de de caracteres não foi definido;
- Em matricula, foi verificado a tipagem e retirado espaços em branco;
- Em nascimento, a condição verificada é a estrutura e formato da data.

   > :warning: As rotas de solicitação e remoção receberam validações manuais

######  🧪 Testes alterados

Foram alterados os testes funcionais para rota dos professores. Foram retirados números presentes no campo nome do formulário.
